### PR TITLE
Added tslint so that it doesn't conflict with other angular projects.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules
+tslint.json


### PR DESCRIPTION
This pull request fixes #35 

Right now if you use ng-socket-io your `ng lint` command will fail with an error similar to this:

```
Failed to load /home/phil/git/project/node_modules/ng-socket-io/tslint.json: Could not find custom rule directory: node_modules/codelyzer
```

This error is caused by tslint config being published to the npm registry. 

There is no need to publish the tslint config file of this project and therefore have added lines to prevent it from being published in the future. This will prevent this error from popping up in the future. 