### PR TITLE
Allow many arguments to be passed to Socket.emit()

### DIFF
--- a/socket-io.service.ts
+++ b/socket-io.service.ts
@@ -33,7 +33,7 @@ export class WrappedSocket {
         return this.ioSocket.disconnect.apply(this.ioSocket, arguments);
     }
 
-    emit(eventName: string, data?: any, callback?: Function) {
+    emit(eventName: string, ...args: any) {
         return this.ioSocket.emit.apply(this.ioSocket, arguments);
     }
 

--- a/socket-io.service.ts
+++ b/socket-io.service.ts
@@ -33,7 +33,7 @@ export class WrappedSocket {
         return this.ioSocket.disconnect.apply(this.ioSocket, arguments);
     }
 
-    emit(eventName: string, ...args: any) {
+    emit(eventName: string, ...args: any[]) {
         return this.ioSocket.emit.apply(this.ioSocket, arguments);
     }
 


### PR DESCRIPTION
Fixes Issue #77 

To get this to work in a deployment I had to change the compiled NPM version, as you've changed the structure a fair bit between 0.1.5 and 0.2.4. However the spirit of this change to the TS works and let's a client emit a multitude of arguments to a server, which is permitted by the underlying Socket.IO